### PR TITLE
Updated README

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,7 @@
   
 * Security Warning
 
-  This plugin uses =system= to communicate with emacs.  Every effort
+  This plugin uses =IPC::open2= to communicate with emacs.  Every effort
   has been made to ensure that the arguments to this function can not
   cause damage, but it is possible that I have missed something.
   Given this, the plugin should not be used in situations where


### PR DESCRIPTION
I just realized I hadn't changed the documentation to reflect the change from the use of system() to IPC::open2() in the "Security Warning" section.
